### PR TITLE
fix: removes wait until published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -750,7 +750,6 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
                             <publishingServerId>central</publishingServerId>
                             <!-- Skip manually logging in to the portal to release the deployment -->
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Publishing on maven central can take upwards of 20min and the Jenkins slave is blocked until fully published which is not ideal.

Refs: FART-595